### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 4.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the namespace of the package to versions using a PEP 420 namespace.
 
 
 3.1 (2025-04-03)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 4.0 (unreleased)
 ================
 
-- Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the namespace of the package to versions using a PEP 420 namespace.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 3.1 (2025-04-03)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 CHANGES
 =======
 
-3.2 (unreleased)
+4.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ TEST_REQUIREMENTS = [
 
 setup(
     name="z3c.flashmessage",
-    version='3.2.dev0',
+    version='4.0.dev0',
     author="Jasper Op de Coul, Christian Theune",
     author_email="jasper@infrae.com, mail@gocept.com",
     description="A package for sending `flash messages` to users.",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os.path
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -13,7 +12,7 @@ TEST_REQUIREMENTS = [
     'zope.publisher',
     'zope.component',
     'zope.security',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
     'zope.app.wsgi[testlayer] >= 4.0',
     'Webtest',
 ]
@@ -50,10 +49,7 @@ setup(
         'Framework :: Zope :: 3',
     ],
     zip_safe=False,
-    packages=find_packages('src'),
     include_package_data=True,
-    package_dir={'': 'src'},
-    namespace_packages=['z3c'],
     python_requires='>=3.9',
     install_requires=[
         'setuptools',

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the namespace of the package to versions using a PEP 420 namespace.**
- **Switch to PEP 420 native namespace.**
